### PR TITLE
Fixer sleep(t/2) triggerbot

### DIFF
--- a/features/aim.cpp
+++ b/features/aim.cpp
@@ -99,7 +99,8 @@ bool clicked = false;
 
 const int trigger_cooldown()
 {
-	return (int) (((rand() % 50)/100) + 0.15F);
+	// Generate a random float between 0.0 and 0.5, add 0.15F to it, then cast to int milliseconds
+	return static_cast<int>((static_cast<float>(rand() % 50) / 100.0F + 0.15F) * 1000);
 }
 
 void aim::triggerBot(LocalPlayer localPlayer, DWORD_PTR base) {
@@ -125,6 +126,7 @@ void aim::triggerBot(LocalPlayer localPlayer, DWORD_PTR base) {
 				{
 					clicked = true;
 					const int t = trigger_cooldown();
+					//printf("Cooldown: %d ms\n", t);  // Correct printf syntax for int
 					mouse_event(MOUSEEVENTF_LEFTDOWN, 0, 0, 0, 0);
 					Sleep(t/2);
 					mouse_event(MOUSEEVENTF_LEFTUP, 0, 0, 0, 0);
@@ -141,6 +143,7 @@ void aim::triggerBot(LocalPlayer localPlayer, DWORD_PTR base) {
 			{
 				clicked = true;
 				const int t = trigger_cooldown();
+				//printf("Cooldown: %d ms\n", t);  // Correct printf syntax for int
 				mouse_event(MOUSEEVENTF_LEFTDOWN, 0, 0, 0, 0);
 				Sleep(t / 2);
 				mouse_event(MOUSEEVENTF_LEFTUP, 0, 0, 0, 0);


### PR DESCRIPTION
trigger_cooldown Logic:

The trigger_cooldown function is returning an int that is a casted result from a floating-point calculation. This calculation might not behave as intended. Specifically: ((rand() % 50) / 100) will always result in 0 because integer division in C++ discards any fractional part. Hence, this expression will always return 0. As a result, your trigger_cooldown function always returns 0.15, which after casting to int, becomes 0. This will affect your sleep and click timing, making it nearly instantaneous.

added a //printf("Cooldown: %d ms\n", t); // Correct printf syntax for int to debug and it's true... old version return 0ms EACH time